### PR TITLE
update to 3.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "flaky" %}
-{% set version = "3.7.0" %}
-{% set hash = "3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d" %}
+{% set version = "3.8.1" %}
+{% set hash = "47204a81ec905f3d5acfbd61daeabcada8f9d4031616d9bcb0618461729699f5" %}
 
 package:
   name: {{ name|lower }}
@@ -14,23 +14,28 @@ source:
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - flaky
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/box/flaky
-  license: Apache 2.0
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: Plugin for nose or py.test that automatically reruns flaky tests.
@@ -38,6 +43,7 @@ about:
     Flaky is a plugin for nose or py.test that automatically reruns flaky
     tests.
   dev_url: https://github.com/box/flaky
+  doc_url: https://github.com/box/flaky
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
flaky 3.8.1

**Destination channel:** main

### Links

- PKG-7271
- https://github.com/box/flaky/tree/v3.8.1

### Explanation of changes:

- For compatibility with pytest 8
- Keeping as noarch. This project seldom gets updated.
